### PR TITLE
Bits are now a recognized unit

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var parsableUnit = function(u) {
 
 var incrementBases = {
   2: [
+    [["b", "bits"], 1/8],
     [["B", "Bytes"], 1],
     [["Kb"], 128],
     [["k", "K", "kb", "KB", "KiB", "Ki", "ki"], 1024],
@@ -23,6 +24,7 @@ var incrementBases = {
     [["e", "E", "eb", "EB", "EiB", "Ei", "ei"], Math.pow(1024, 6)]
   ],
   10: [
+    [["b", "bits"], 1/8],
     [["B", "Bytes"], 1],
     [["Kb"], 125],
     [["k", "K", "kb", "KB", "KiB", "Ki", "ki"], 1000],

--- a/test.js
+++ b/test.js
@@ -18,6 +18,10 @@ assert.equal(filesizeParser('100'), 100);
 //if you /reallllly/ want kilobits...
 assert.equal(filesizeParser('1Kb'), 128);
 
+//passing in bits should work
+assert.equal(filesizeParser('1000b'), 125);
+assert.equal(filesizeParser('1000bits'), 125);
+
 //ignore whitespace, even stupid amounts of it
 assert.equal(filesizeParser('1                     KB'), 1024);
 


### PR DESCRIPTION
I added management of bits units, using either `b` or `bits`.

```js
filesizeParser('1000b'); // returns 125
filesizeParser('1000bits'); // returns 125 too
```

I choosed to only manage `bits`, not  `Bits` because uppercase `B` means `Bytes` and it would be confusing.

I obviously added two units tests to verify it.