### PR TITLE
Return value is now ceiled

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,14 +57,14 @@ module.exports = function (input) {
   if (!validAmount(amount) || !parsableUnit(unit)) {
     throw 'Can\'t interpret ' + (input || 'a blank string');
   }
-  if (unit === '') return Number(amount);
+  if (unit === '') return Math.ceil(Number(amount));
 
   var increments = incrementBases[base];
   for (var i = 0; i < increments.length; i++) {
     var _increment = increments[i];
 
     if (_increment[0].some(validUnit)) {
-      return amount * _increment[1];
+      return Math.ceil(amount * _increment[1]);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -57,14 +57,14 @@ module.exports = function (input) {
   if (!validAmount(amount) || !parsableUnit(unit)) {
     throw 'Can\'t interpret ' + (input || 'a blank string');
   }
-  if (unit === '') return Math.ceil(Number(amount));
+  if (unit === '') return Math.round(Number(amount));
 
   var increments = incrementBases[base];
   for (var i = 0; i < increments.length; i++) {
     var _increment = increments[i];
 
     if (_increment[0].some(validUnit)) {
-      return Math.ceil(amount * _increment[1]);
+      return Math.round(amount * _increment[1]);
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -42,6 +42,10 @@ assert.equal(filesizeParser('2,5Ti'),2748779069440);
 //lower case should work
 assert.equal(filesizeParser('2ti'),2199023255552);
 
+//don't return floating numbers
+assert.equal(filesizeParser('2.156KiB'),2208);
+assert.equal(filesizeParser('100.1'),101);
+
 //unknown units should throw an error
 assert.throws(function() {filesizeParser('1pk');});
 
@@ -94,6 +98,9 @@ assert.equal(filesizeParser('1Gi', {base: 10}),1000000000);
 assert.equal(filesizeParser('1Ti', {base: 10}),1000000000000);
 assert.equal(filesizeParser('1Pi', {base: 10}),1000000000000000);
 assert.equal(filesizeParser('1Ei', {base: 10}),1000000000000000000);
+
+//don't return floating numbers
+assert.equal(filesizeParser('2.1562Ki', {base: 10}),2157);
 
 //unknown units should throw an error
 assert.throws(function() {filesizeParser('1pk', {base: 10});});

--- a/test.js
+++ b/test.js
@@ -44,7 +44,8 @@ assert.equal(filesizeParser('2ti'),2199023255552);
 
 //don't return floating numbers
 assert.equal(filesizeParser('2.156KiB'),2208);
-assert.equal(filesizeParser('100.1'),101);
+assert.equal(filesizeParser('100.1'),100);
+assert.equal(filesizeParser('100.6'),101);
 
 //unknown units should throw an error
 assert.throws(function() {filesizeParser('1pk');});
@@ -100,7 +101,7 @@ assert.equal(filesizeParser('1Pi', {base: 10}),1000000000000000);
 assert.equal(filesizeParser('1Ei', {base: 10}),1000000000000000000);
 
 //don't return floating numbers
-assert.equal(filesizeParser('2.1562Ki', {base: 10}),2157);
+assert.equal(filesizeParser('2.1565Ki', {base: 10}),2157);
 
 //unknown units should throw an error
 assert.throws(function() {filesizeParser('1pk', {base: 10});});


### PR DESCRIPTION
The module does not returns floating numbers anymore. Floating numbers have been ceiled to avoid it.
I added 3 tests to verify it.

```js
var filesizeParser = require('filesize-parser');
filesizeParser('2.1GiB'); // now returns 2254857831 instead of 2254857830.4
filesizeParser('2.156KiB'); // now returns 2208 instead of 2207.744
filesizeParser(100.1); // now returns 101 instead of 100.1
```

This fix issue #12.