### PR TITLE
Add lasts node versions to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: false
 language: node_js
 node_js:
+  - "6"
+  - "5"
+  - "4"
+  - "0.12"
   - "0.11"
   - "0.10"
   - "0.8"


### PR DESCRIPTION
I updated `.travis.yml` file to make it using node.js versions `0.12`, `4`, `5` (even if it's not maintained by node.js team) and `6`.